### PR TITLE
Changed method of getting cvar interface, and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+projects

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Alot of servers now are in danger now, because `lua_dumptimers_sv` concommand ar
 Compiled binaries are not ready for CentOS and have newest C++ version (so C++ < 6 isn't working)
 
 ## Notes:
-This is serverside module, do not try to run it on your Garry's Mod instance, its compiled to work only in SRCDS.
+-
 
 ## Build:
 Don't forget to install [garrysmod_common](https://github.com/danielga/garrysmod_common), this fix depends on it.

--- a/premake5.lua
+++ b/premake5.lua
@@ -10,5 +10,7 @@ include(assert(_OPTIONS.gmcommon or os.getenv("GARRYSMOD_COMMON"), "you didn't p
 
 CreateWorkspace {name = "dumptimers_fix"}
     CreateProject {serverside = true}
+        IncludeSDKTier0()
         IncludeSDKCommon()
+        IncludeHelpersExtended()
         files {"src/fix.cpp"}

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -26,11 +26,12 @@ SOFTWARE.
 
 #include <GarrysMod/Lua/Interface.h>
 #include <GarrysMod/Interfaces.hpp>
+#include <GarrysMod/InterfacePointers.hpp>
 
 #include <icvar.h>
 
 GMOD_MODULE_OPEN() {
-	ICvar *icvar = SourceSDK::FactoryLoader("vstdlib", true, IS_SERVERSIDE, "bin/").GetInterface<ICvar>(CVAR_INTERFACE_VERSION);
+	ICvar *icvar = InterfacePointers::Cvar();
 	ConCommandBase *lua_dumptimers_sv = icvar->FindCommandBase("lua_dumptimers_sv");
 	if (lua_dumptimers_sv) icvar->UnregisterConCommand(lua_dumptimers_sv);
 	return 0;


### PR DESCRIPTION
What I have done:
* Instead of getting `CVar` interface directly using `SourceSDK::FactoryLoader`, I changed it to using `InterfacePointers::Cvar()`, so this module will use needed dll based on platform. Also now it works on Garry's mod instance.
* Added `projects` folder to the .gitignore file, so git won't include garbage.
* Added missing includes (`tier0` and `helpers_extended`). Previously I couldn't compile this module because tier0 was missing. Also `helpers_extended` was added, so we can use `InterfacePointers`.
* Removed note from readme, that states what this module doesn't work under Garry's mod instance.